### PR TITLE
feat: use `derive_more` to derive `Deref`, `Display` and `From`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2086,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "derive_more",
  "jsonwebtoken",
  "matches",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 [dependencies]
 async-trait = "0.1.88"
 chrono = { version = "0.4.40", features = ["serde"] }
+derive_more = { version = "2.0.1", features = ["deref", "display", "from"] }
 jsonwebtoken = "9.3.1"
 querystring = "1.1.0"
 reqwest = { version = "0.12.0", features = ["json"] }

--- a/src/admin_portal/operations/generate_portal_link.rs
+++ b/src/admin_portal/operations/generate_portal_link.rs
@@ -6,7 +6,7 @@ use crate::organizations::OrganizationId;
 use crate::{ResponseExt, WorkOsResult};
 
 /// The intent of an Admin Portal session.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AdminPortalIntent {
     /// The Admin Portal will be used to setup Single Sign-On (SSO).

--- a/src/core/types/api_key.rs
+++ b/src/core/types/api_key.rs
@@ -1,25 +1,7 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::Serialize;
 
 /// An API key to authenticate with the WorkOS API.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[from(forward)]
 pub struct ApiKey(String);
-
-impl Display for ApiKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for ApiKey {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for ApiKey {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/core/types/metadata.rs
+++ b/src/core/types/metadata.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// The metadata key/value paris associated with an object.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Metadata(pub HashMap<String, String>);
 
 #[cfg(test)]

--- a/src/core/types/paginated_list.rs
+++ b/src/core/types/paginated_list.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A paginated list of records.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PaginatedList<T> {
     /// The list of items in the current page.
     pub data: Vec<T>,
@@ -12,7 +12,7 @@ pub struct PaginatedList<T> {
 }
 
 /// The metadata for a [`PaginatedList`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ListMetadata {
     /// The pagination cursor used to retrieve the previous page of records.
     pub before: Option<String>,

--- a/src/core/types/pagination_params.rs
+++ b/src/core/types/pagination_params.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// The parameters used to control pagination for a given paginated endpoint.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct PaginationParams<'a> {
     /// The order in which records should be paginated.
     pub order: &'a PaginationOrder,
@@ -24,7 +24,7 @@ impl Default for PaginationParams<'_> {
 }
 
 /// The order in which records should be returned when paginating.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PaginationOrder {
     /// Records are returned in ascending order.

--- a/src/core/types/raw_attributes.rs
+++ b/src/core/types/raw_attributes.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// The raw attributes returned from the Identity or Directory Provider.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RawAttributes(pub HashMap<String, Value>);
 
 #[cfg(test)]

--- a/src/core/types/timestamps.rs
+++ b/src/core/types/timestamps.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
 /// A UTC timestamp.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Timestamp(pub DateTime<FixedOffset>);
 
 impl TryFrom<String> for Timestamp {
@@ -22,7 +22,7 @@ impl TryFrom<&str> for Timestamp {
 }
 
 /// The timestamps for an object.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Timestamps {
     /// The timestamp indicating when the object was created.
     pub created_at: Timestamp,

--- a/src/directory_sync/types/directory.rs
+++ b/src/directory_sync/types/directory.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::directory_sync::DirectoryType;
@@ -7,29 +6,14 @@ use crate::organizations::OrganizationId;
 use crate::{KnownOrUnknown, Timestamps};
 
 /// The ID of a [`Directory`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct DirectoryId(String);
 
-impl Display for DirectoryId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for DirectoryId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for DirectoryId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// The state of a [`Directory`].
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DirectoryState {
     /// The directory is inactve.

--- a/src/directory_sync/types/directory_group.rs
+++ b/src/directory_sync/types/directory_group.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::directory_sync::DirectoryId;
@@ -7,29 +6,14 @@ use crate::organizations::OrganizationId;
 use crate::{RawAttributes, Timestamps};
 
 /// The ID of a [`DirectoryGroup`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct DirectoryGroupId(String);
 
-impl Display for DirectoryGroupId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for DirectoryGroupId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for DirectoryGroupId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Directory Group](https://workos.com/docs/reference/directory-sync/directory-group)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryGroup {
     /// Unique identifier for the Directory Group.
     pub id: DirectoryGroupId,

--- a/src/directory_sync/types/directory_type.rs
+++ b/src/directory_sync/types/directory_type.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The type of a [`Directory`](crate::directory_sync::Directory).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DirectoryType {
     /// Azure AD SCIM v2.0.
     ///

--- a/src/directory_sync/types/directory_user.rs
+++ b/src/directory_sync/types/directory_user.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::fmt::Display;
 
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -9,29 +9,14 @@ use crate::organizations::OrganizationId;
 use crate::{KnownOrUnknown, RawAttributes, Timestamps};
 
 /// The ID of a [`DirectoryUser`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct DirectoryUserId(String);
 
-impl Display for DirectoryUserId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for DirectoryUserId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for DirectoryUserId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Directory User](https://workos.com/docs/reference/directory-sync/directory-user)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryUser<TCustomAttributes = HashMap<String, Value>> {
     /// The ID of the directory user.
     pub id: DirectoryUserId,
@@ -82,7 +67,7 @@ impl DirectoryUser {
 }
 
 /// The state of a [`DirectoryUser`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DirectoryUserState {
     /// The directory user is active.
@@ -96,7 +81,7 @@ pub enum DirectoryUserState {
 }
 
 /// An email address for a [`DirectoryUser`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryUserEmail {
     /// Whether this is the directory user's primary email address.
     pub primary: Option<bool>,

--- a/src/known_or_unknown.rs
+++ b/src/known_or_unknown.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// `KnownOrUnknown` is a type that respresents either a known value ([`Known`](KnownOrUnknown::Known))
 /// or an unknown value ([`Unknown`](KnownOrUnknown::Unknown)).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum KnownOrUnknown<K, U> {
     /// A known value.

--- a/src/mfa/types/authentication_challenge.rs
+++ b/src/mfa/types/authentication_challenge.rs
@@ -1,34 +1,18 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::mfa::AuthenticationFactorId;
 use crate::{Timestamp, Timestamps};
 
 /// The ID of an [`AuthenticationChallenge`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct AuthenticationChallengeId(String);
 
-impl Display for AuthenticationChallengeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for AuthenticationChallengeId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for AuthenticationChallengeId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Authentication Challenge](https://workos.com/docs/reference/mfa/authentication-challenge)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthenticationChallenge {
     /// The ID of the authentication challenge.
     pub id: AuthenticationChallengeId,

--- a/src/mfa/types/authentication_factor.rs
+++ b/src/mfa/types/authentication_factor.rs
@@ -1,33 +1,17 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::Timestamps;
 
 /// The ID of an [`AuthenticationFactor`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct AuthenticationFactorId(String);
 
-impl Display for AuthenticationFactorId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for AuthenticationFactorId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for AuthenticationFactorId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Authentication Factor](https://workos.com/docs/reference/mfa/authentication-factor)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthenticationFactor {
     /// The ID of the authentication factor.
     pub id: AuthenticationFactorId,
@@ -42,7 +26,7 @@ pub struct AuthenticationFactor {
 }
 
 /// The type of an [`AuthenticationFactor`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthenticationFactorType {
     /// Time-based one-time password (TOTP).

--- a/src/mfa/types/mfa_code.rs
+++ b/src/mfa/types/mfa_code.rs
@@ -1,25 +1,7 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::Serialize;
 
 /// A multi-factor authentication (MFA) code.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[from(forward)]
 pub struct MfaCode(String);
-
-impl Display for MfaCode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for MfaCode {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for MfaCode {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/organizations/types/organization.rs
+++ b/src/organizations/types/organization.rs
@@ -1,33 +1,17 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::Timestamps;
 
 /// The ID of an [`Organization`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct OrganizationId(String);
 
-impl Display for OrganizationId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for OrganizationId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for OrganizationId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Organization](https://workos.com/docs/reference/organization)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Organization {
     /// The ID of the organization.
     pub id: OrganizationId,
@@ -52,29 +36,14 @@ pub struct Organization {
 }
 
 /// The ID of an [`OrganizationDomain`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct OrganizationDomainId(String);
 
-impl Display for OrganizationDomainId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for OrganizationDomainId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for OrganizationDomainId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Organization Domain](https://workos.com/docs/reference/organization-domain)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OrganizationDomain {
     /// The ID of the organization domain.
     pub id: OrganizationDomainId,

--- a/src/passwordless/types/passwordless_session.rs
+++ b/src/passwordless/types/passwordless_session.rs
@@ -1,33 +1,17 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::Timestamp;
 
 /// The ID of an [`PasswordlessSession`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct PasswordlessSessionId(String);
 
-impl Display for PasswordlessSessionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for PasswordlessSessionId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for PasswordlessSessionId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// The type of a [`PasswordlessSession`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PasswordlessSessionType {
     /// Magic Link.
@@ -41,7 +25,7 @@ pub enum PasswordlessSessionType {
 }
 
 /// [WorkOS Docs: Passwordless Session](https://workos.com/docs/reference/magic-link/passwordless-session)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PasswordlessSession {
     /// The ID of the passwordless session.
     pub id: PasswordlessSessionId,

--- a/src/sso/operations/get_authorization_url.rs
+++ b/src/sso/operations/get_authorization_url.rs
@@ -4,7 +4,7 @@ use crate::organizations::OrganizationId;
 use crate::sso::{ClientId, ConnectionId, Sso};
 
 /// An OAuth provider to use for Single Sign-On (SSO).
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Provider {
     /// Sign in with Google OAuth.
     GoogleOauth,

--- a/src/sso/types/access_token.rs
+++ b/src/sso/types/access_token.rs
@@ -1,25 +1,9 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 /// An access token that may be exchanged for a [`Profile`](crate::sso::Profile).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct AccessToken(String);
-
-impl Display for AccessToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for AccessToken {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for AccessToken {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/sso/types/authorization_code.rs
+++ b/src/sso/types/authorization_code.rs
@@ -1,26 +1,8 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::Serialize;
 
 /// An authorization code that may be exchanged for an SSO profile and access
 /// token.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[from(forward)]
 pub struct AuthorizationCode(String);
-
-impl Display for AuthorizationCode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for AuthorizationCode {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for AuthorizationCode {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/sso/types/client_id.rs
+++ b/src/sso/types/client_id.rs
@@ -1,27 +1,9 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::Serialize;
 
 /// A client ID used to initiate SSO.
 ///
 /// Each environment will have its own client ID.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[from(forward)]
 pub struct ClientId(String);
-
-impl Display for ClientId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for ClientId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for ClientId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/sso/types/connection.rs
+++ b/src/sso/types/connection.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::organizations::OrganizationId;
@@ -7,29 +6,14 @@ use crate::sso::ConnectionType;
 use crate::{KnownOrUnknown, Timestamps};
 
 /// The ID of a [`Connection`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct ConnectionId(String);
 
-impl Display for ConnectionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for ConnectionId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for ConnectionId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// The state of a [`Connection`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionState {
     /// The connection is active.
@@ -40,7 +24,7 @@ pub enum ConnectionState {
 }
 
 /// [WorkOS Docs: Connection](https://workos.com/docs/reference/sso/connection)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Connection {
     /// The ID of the connection.
     pub id: ConnectionId,

--- a/src/sso/types/connection_type.rs
+++ b/src/sso/types/connection_type.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The type of a [`Connection`](crate::sso::Connection).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConnectionType {
     /// AD FS SAML.
     ///

--- a/src/sso/types/profile.rs
+++ b/src/sso/types/profile.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::organizations::OrganizationId;
@@ -8,29 +7,14 @@ use crate::{KnownOrUnknown, RawAttributes};
 use super::{ConnectionId, ConnectionType};
 
 /// The ID of a [`Profile`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct ProfileId(String);
 
-impl Display for ProfileId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for ProfileId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for ProfileId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: Profile](https://workos.com/docs/reference/sso/profile)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Profile {
     /// The ID of the profile.
     pub id: ProfileId,

--- a/src/user_management/operations/get_authorization_url.rs
+++ b/src/user_management/operations/get_authorization_url.rs
@@ -12,7 +12,7 @@ pub enum CodeChallenge<'a> {
 }
 
 /// Which AuthKit screen users should land on upon redirection.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ScreenHint {
     /// Sign up screen.
     SignUp,
@@ -22,7 +22,7 @@ pub enum ScreenHint {
 }
 
 /// An OAuth provider to use for Single Sign-On (SSO) or AuthKit.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Provider {
     /// Sign in with AuthKit.
     AuthKit {

--- a/src/user_management/types/authenticate_error.rs
+++ b/src/user_management/types/authenticate_error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::{WorkOsError, WorkOsResult};
 
 /// An error returned from authenticate requests.
-#[derive(Debug, Error, Deserialize)]
+#[derive(Debug, Deserialize, Error)]
 #[error("{code}: {message}")]
 pub struct AuthenticateError {
     #[serde(alias = "error")]

--- a/src/user_management/types/authentication_response.rs
+++ b/src/user_management/types/authentication_response.rs
@@ -5,7 +5,7 @@ use crate::{organizations::OrganizationId, sso::AccessToken};
 use super::{Impersonator, RefreshToken, User};
 
 /// The authentication method used to initiate the session.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 pub enum AuthenticationMethod {
     /// Single Sign-On (SSO)
     SSO,

--- a/src/user_management/types/impersonator.rs
+++ b/src/user_management/types/impersonator.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// [WorkOS Docs: Impersonation](https://workos.com/docs/user-management/impersonation)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Impersonator {
     /// The email address of the WorkOS Dashboard user who is impersonating the user
     pub email: String,

--- a/src/user_management/types/refresh_token.rs
+++ b/src/user_management/types/refresh_token.rs
@@ -1,25 +1,9 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 /// A refresh token that may be exchanged for a new [`AccessToken`](crate::sso::AccessToken).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct RefreshToken(String);
-
-impl Display for RefreshToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for RefreshToken {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for RefreshToken {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/user_management/types/session_id.rs
+++ b/src/user_management/types/session_id.rs
@@ -1,25 +1,7 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::Serialize;
 
 /// The ID of a session.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[from(forward)]
 pub struct SessionId(String);
-
-impl Display for SessionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for SessionId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for SessionId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}

--- a/src/user_management/types/user.rs
+++ b/src/user_management/types/user.rs
@@ -1,34 +1,18 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{Metadata, Timestamp, Timestamps};
 
 /// The ID of a [`User`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct UserId(String);
 
-impl Display for UserId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for UserId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for UserId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// [WorkOS Docs: User](https://workos.com/docs/reference/user-management/user)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct User {
     /// The unique ID of the user.
     pub id: UserId,

--- a/src/webhooks/types/directory.rs
+++ b/src/webhooks/types/directory.rs
@@ -5,7 +5,7 @@ use crate::organizations::OrganizationId;
 use crate::{KnownOrUnknown, Timestamps};
 
 /// The state of a [`Directory`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DirectoryState {
     /// The directory is linked.
@@ -19,7 +19,7 @@ pub enum DirectoryState {
 }
 
 /// [WorkOS Docs: Directory](https://workos.com/docs/reference/directory-sync/directory)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Directory {
     /// The ID of the directory.
     pub id: DirectoryId,

--- a/src/webhooks/types/events/connection_activated.rs
+++ b/src/webhooks/types/events/connection_activated.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::sso::Connection;
 
 /// [WorkOS Docs: `connection.activated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.activated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct ConnectionActivatedWebhook(pub Connection);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/connection_deactivated.rs
+++ b/src/webhooks/types/events/connection_deactivated.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::sso::Connection;
 
 /// [WorkOS Docs: `connection.deactivated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.deactivated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct ConnectionDeactivatedWebhook(pub Connection);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/connection_deleted.rs
+++ b/src/webhooks/types/events/connection_deleted.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::sso::Connection;
 
 /// [WorkOS Docs: `connection.activated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.activated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct ConnectionDeletedWebhook(pub Connection);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_activated.rs
+++ b/src/webhooks/types/events/directory_activated.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::webhooks::Directory;
 
 /// [WorkOS Docs: `dsync.activated` Webhook](https://workos.com/docs/reference/webhooks/directory#webhooks-dsync.activated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryActivatedWebhook(pub Directory);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_deactivated.rs
+++ b/src/webhooks/types/events/directory_deactivated.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::webhooks::Directory;
 
 /// [WorkOS Docs: `dsync.deactivated` Webhook](https://workos.com/docs/reference/webhooks/directory#webhooks-dsync.deactivated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryDeactivatedWebhook(pub Directory);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_deleted.rs
+++ b/src/webhooks/types/events/directory_deleted.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::webhooks::Directory;
 
 /// [WorkOS Docs: `dsync.deleted` Webhook](https://workos.com/docs/reference/webhooks/directory#webhooks-dsync.deleted)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryDeletedWebhook(pub Directory);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_group_created.rs
+++ b/src/webhooks/types/events/directory_group_created.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::DirectoryGroup;
 
 /// [WorkOS Docs: `dsync.group.created` Webhook](https://workos.com/docs/reference/webhooks/directory-group#webhooks-dsync.group.created)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryGroupCreatedWebhook(pub DirectoryGroup);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_group_deleted.rs
+++ b/src/webhooks/types/events/directory_group_deleted.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::DirectoryGroup;
 
 /// [WorkOS Docs: `dsync.group.deleted` Webhook](https://workos.com/docs/reference/webhooks/directory-group#webhooks-dsync.group.deleted)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryGroupDeletedWebhook(pub DirectoryGroup);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_group_updated.rs
+++ b/src/webhooks/types/events/directory_group_updated.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::directory_sync::DirectoryGroup;
 
 /// A [`DirectoryGroup`] with its previous attributes.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryGroupWithPreviousAttributes {
     /// The directory group.
     #[serde(flatten)]
@@ -17,7 +17,7 @@ pub struct DirectoryGroupWithPreviousAttributes {
 }
 
 /// [WorkOS Docs: `dsync.group.updated` Webhook](https://workos.com/docs/reference/webhooks/directory-group#webhooks-dsync.group.updated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryGroupUpdatedWebhook(pub DirectoryGroupWithPreviousAttributes);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_group_user_added.rs
+++ b/src/webhooks/types/events/directory_group_user_added.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::{DirectoryGroup, DirectoryId, DirectoryUser};
 
 /// [WorkOS Docs: `dsync.group.user_added` Webhook](https://workos.com/docs/reference/webhooks/directory-group#webhooks-dsync.group.user_added)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserAddedToGroupWebhook {
     /// The directory ID.
     pub directory_id: DirectoryId,

--- a/src/webhooks/types/events/directory_group_user_removed.rs
+++ b/src/webhooks/types/events/directory_group_user_removed.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::{DirectoryGroup, DirectoryId, DirectoryUser};
 
 /// [WorkOS Docs: `dsync.group.user_removed` Webhook](https://workos.com/docs/reference/webhooks/directory-group#webhooks-dsync.group.user_removed)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserRemovedFromGroupWebhook {
     /// The directory ID.
     pub directory_id: DirectoryId,

--- a/src/webhooks/types/events/directory_user_created.rs
+++ b/src/webhooks/types/events/directory_user_created.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::DirectoryUser;
 
 /// [WorkOS Docs: `dsync.user.created` Webhook](https://workos.com/docs/reference/webhooks/directory-user#webhooks-dsync.user.created)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserCreatedWebhook(pub DirectoryUser);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_user_deleted.rs
+++ b/src/webhooks/types/events/directory_user_deleted.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::directory_sync::DirectoryUser;
 
 /// [WorkOS Docs: `dsync.user.deleted` Webhook](https://workos.com/docs/reference/webhooks/directory-user#webhooks-dsync.user.deleted)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserDeletedWebhook(pub DirectoryUser);
 
 #[cfg(test)]

--- a/src/webhooks/types/events/directory_user_updated.rs
+++ b/src/webhooks/types/events/directory_user_updated.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::directory_sync::DirectoryUser;
 
 /// A [`DirectoryUser`] with their previous attributes.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserWithPreviousAttributes {
     /// The directory user.
     #[serde(flatten)]
@@ -17,7 +17,7 @@ pub struct DirectoryUserWithPreviousAttributes {
 }
 
 /// [WorkOS Docs: `dsync.user.updated` Webhook](https://workos.com/docs/reference/webhooks/directory-user#webhooks-dsync.user.updated)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct DirectoryUserUpdatedWebhook(pub DirectoryUserWithPreviousAttributes);
 
 #[cfg(test)]

--- a/src/webhooks/types/webhook.rs
+++ b/src/webhooks/types/webhook.rs
@@ -1,33 +1,17 @@
-use std::fmt::Display;
-
+use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 use crate::webhooks::WebhookEvent;
 
 /// The ID of a [`Webhook`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Deref, Display, From, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[from(forward)]
 pub struct WebhookId(String);
 
-impl Display for WebhookId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<String> for WebhookId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for WebhookId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 /// A WorkOS webhook.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct Webhook {
     /// The ID of the webhook.
     pub id: WebhookId,

--- a/src/webhooks/types/webhook_event.rs
+++ b/src/webhooks/types/webhook_event.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use super::events::*;
 
 /// The event of a [`Webhook`](crate::webhooks::Webhook).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(tag = "event", content = "data")]
 pub enum WebhookEvent {
     /// [WorkOS Docs: `connection.activated` Webhook](https://workos.com/docs/reference/webhooks/connection#webhooks-sso.connection.activated)


### PR DESCRIPTION
Closes #20.

Use [`derive_more`](https://crates.io/crates/derive_more) to derive  `Deref`, `Display` and `From`.