### PR TITLE
feat(user-management): add authenticate with email verification

### DIFF
--- a/src/user_management/operations.rs
+++ b/src/user_management/operations.rs
@@ -1,4 +1,5 @@
 mod authenticate_with_code;
+mod authenticate_with_email_verification;
 mod authenticate_with_magic_auth;
 mod authenticate_with_password;
 mod authenticate_with_refresh_token;
@@ -13,6 +14,7 @@ mod get_user_identities;
 mod list_users;
 
 pub use authenticate_with_code::*;
+pub use authenticate_with_email_verification::*;
 pub use authenticate_with_magic_auth::*;
 pub use authenticate_with_password::*;
 pub use authenticate_with_refresh_token::*;

--- a/src/user_management/operations/authenticate_with_magic_auth.rs
+++ b/src/user_management/operations/authenticate_with_magic_auth.rs
@@ -31,7 +31,10 @@ pub struct AuthenticateWithMagicAuthParams<'a> {
 
 #[derive(Serialize)]
 struct AuthenticateWithMagicAuthBody<'a> {
+    /// Authenticates the application making the request to the WorkOS server.
     client_secret: &'a ApiKey,
+
+    /// A string constant that distinguishes the method by which your application will receive an access token.
     grant_type: &'a str,
 
     #[serde(flatten)]
@@ -41,7 +44,7 @@ struct AuthenticateWithMagicAuthBody<'a> {
 /// [WorkOS Docs: Authenticate with Magic Auth](https://workos.com/docs/reference/user-management/authentication/magic-auth)
 #[async_trait]
 pub trait AuthenticateWithMagicAuth {
-    /// Authenticates a user by verifying the Magic Auth code sent to the user’s email.
+    /// Authenticates a user by verifying the Magic Auth code sent to the user's email.
     ///
     /// [WorkOS Docs: Authenticate with Magic Auth](https://workos.com/docs/reference/user-management/authentication/magic-auth)
     ///

--- a/src/user_management/operations/authenticate_with_password.rs
+++ b/src/user_management/operations/authenticate_with_password.rs
@@ -33,7 +33,10 @@ pub struct AuthenticateWithPasswordParams<'a> {
 
 #[derive(Serialize)]
 struct AuthenticateWithPasswordBody<'a> {
+    /// Authenticates the application making the request to the WorkOS server.
     client_secret: &'a ApiKey,
+
+    /// A string constant that distinguishes the method by which your application will receive an access token.
     grant_type: &'a str,
 
     #[serde(flatten)]

--- a/src/user_management/operations/authenticate_with_refresh_token.rs
+++ b/src/user_management/operations/authenticate_with_refresh_token.rs
@@ -32,7 +32,10 @@ pub struct AuthenticateWithRefreshTokenParams<'a> {
 
 #[derive(Serialize)]
 struct AuthenticateWithRefreshTokenBody<'a> {
+    /// Authenticates the application making the request to the WorkOS server.
     client_secret: &'a ApiKey,
+
+    /// A string constant that distinguishes the method by which your application will receive an access token.
     grant_type: &'a str,
 
     #[serde(flatten)]

--- a/src/user_management/operations/create_user.rs
+++ b/src/user_management/operations/create_user.rs
@@ -21,7 +21,7 @@ pub struct CreateUserParams<'a> {
     /// The last name of the user.
     pub last_name: Option<&'a str>,
 
-    /// Whether the user’s email address was previously verified.
+    /// Whether the user's email address was previously verified.
     pub email_verified: Option<bool>,
 
     /// The external ID of the user.


### PR DESCRIPTION
Add [User Management - Authenticate with an email verification code](https://workos.com/docs/reference/user-management/authentication/email-verification) endpoint.